### PR TITLE
Allow pass through of errors generated inside Backbone.sync()

### DIFF
--- a/servers/Route.bones
+++ b/servers/Route.bones
@@ -97,8 +97,8 @@ server.prototype.loadCollection = function(req, res, next) {
                 res.send(resp, headers);
             },
             error: function(collection, err) {
-                err = err instanceof Object ? err.toString() : err;
-                next(new Error.HTTP(err, 500));
+                error = err instanceof Object ? err.toString() : err;
+                next(new Error.HTTP(error, err && err.status || 500));
             }
         });
     } else {
@@ -122,8 +122,8 @@ server.prototype.getModel = function(req, res, next) {
             res.send(resp, headers);
         },
         error: function(model, err) {
-            err = err instanceof Object ? err.toString() : err;
-            next(new Error.HTTP(err, 404));
+            error = err instanceof Object ? err.toString() : err;
+            next(new Error.HTTP(error, err && err.status || 404));
         }
     });
 };
@@ -135,8 +135,8 @@ server.prototype.saveModel = function(req, res, next) {
             res.send(resp, headers);
         },
         error: function(model, err) {
-            err = err instanceof Object ? err.toString() : err;
-            next(new Error.HTTP(err, 409));
+            error = err instanceof Object ? err.toString() : err;
+            next(new Error.HTTP(error, err && err.status || 409));
         }
     });
 };
@@ -148,8 +148,8 @@ server.prototype.delModel = function(req, res, next) {
             res.send({}, headers);
         },
         error: function(model, err) {
-            err = err instanceof Object ? err.toString() : err;
-            next(new Error.HTTP(err, 409));
+            error = err instanceof Object ? err.toString() : err;
+            next(new Error.HTTP(error, err && err.status || 409));
         }
     });
 };


### PR DESCRIPTION
@kkaefer, what do you think of this commit? I ran into an issue where I can't trigger a 500 error from within a Backbone.sync implementation. It is always overridden with a 409 status code and Bones [only masks and logs messages for 500 errors](https://github.com/developmentseed/bones/blob/1.3/server/middleware.js#L74-77).
