### PR TITLE
allow head requests 

### DIFF
--- a/server/middleware.js
+++ b/server/middleware.js
@@ -41,7 +41,7 @@ exports['sanitizeHost'] = function sanitizeHost(app) {
 
 exports['validateCSRFToken'] = function validateCSRFToken() {
     return function(req, res, next) {
-        if (req.method === 'GET') {
+        if (req.method === 'GET' || req.method === 'HEAD') {
             next();
         } else if (req.body && req.cookies['bones.token'] && req.body['bones.token'] === req.cookies['bones.token']) {
             delete req.body['bones.token'];


### PR DESCRIPTION
Issuing a HEAD request against a Tilemill tile leads to an error:

```
$ curl -I http://localhost:8889/tile/autostyle/2/1/1.png
HTTP/1.1 403 Forbidden
X-Powered-By: Express
Content-Type: text/plain
Connection: keep-alive
```

And terminal output like: 'This type of response MUST NOT have a body. Ignoring data passed to end()'

This pull fixes the problem and allows the head request to complete:

```
$ curl -I http://localhost:8889/tile/autostyle/2/1/1.png
HTTP/1.1 200 OK
X-Powered-By: Express
Content-Type: image/png
Content-Length: 19642
max-age: 3600
Connection: keep-alive
```
