### PR TITLE
Clone argv

### DIFF
--- a/server/plugin.js
+++ b/server/plugin.js
@@ -125,7 +125,7 @@ Plugin.prototype.add = function(component, filename) {
 };
 
 Plugin.prototype.start = function(callback) {
-    this.argv = require('optimist').argv;
+    this.argv = _(require('optimist').argv).clone();
 
     var command = this.argv._.length ? this.argv._[0] : 'start';
     if (this.argv.help || !(command in this.commands)) {


### PR DESCRIPTION
I ran into a problem in TileMill where something was removing the port setting from optimist's shared argv hash. I tried to hunt down what it was but couldn't find it in a reasonable amount of time.

I don't think we every rely on argv passing side-effects (I don't think this is a good idea anyway).
