### PR TITLE
Collections were omitted from switch to ".bones.js" filename convention

### DIFF
--- a/server/collection.js
+++ b/server/collection.js
@@ -10,7 +10,8 @@ Backbone.Collection.toString = function() {
 Backbone.Collection.register = function(app) {
     // Add the collection if it's not a server-only collection.
     this.files.forEach(function(filename) {
-        if (!(/\.server\.bones$/).test(filename) && app.assets) {
+        if (!(/\.server\.bones(\.js|)$/).test(filename) && app.assets &&
+            app.assets.models.indexOf(filename) < 0) {
             app.assets.models.push(filename);
         }
     });


### PR DESCRIPTION
This poses a potential security risk when using the filename convention _Collection.server.bones.js_ as it ends up sending it to the client.
