### PR TITLE
Return model on callback for client/server consistency.

### DIFF
--- a/shared/utils.js
+++ b/shared/utils.js
@@ -7,7 +7,7 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
 
 Bones.utils.callback = function(callback) {
     return {
-        success: function(model, response) { callback(null, response); },
+        success: function(model, response) { callback(null, model); },
         error: function(model, err) { callback(err); }
     };
 };


### PR DESCRIPTION
When calling `Bones.util.callback()`, if the routing is done from the client, it returns a response object, rather than a `model`. If the routing is coming from the server, it returns a full `model`. This creates consistency problems when typing a URL versus using client-side routing/push-state.

By returning the `model` instead or the `response`, the callback will behave the same way for both routing scenarios.
