### PR TITLE
Backbone.sync should accept $.ajax() settings

### DIFF
--- a/client/backbone.js
+++ b/client/backbone.js
@@ -47,10 +47,16 @@ Backbone.sync = function(method, model, options) {
         'read'  : 'GET'
     }[method];
 
+    var modelJSON = model.toJSON ? model.toJSON() : model;
     if (method !== 'read') {
-        var modelJSON = model.toJSON ? model.toJSON() : model;
         modelJSON['bones.token'] = Backbone.csrf(getUrl(model));
         modelJSON = JSON.stringify(modelJSON);
+    }
+
+    // Merge query string with model attributes
+    if (options.data) {
+        modelJSON = _.extend(modelJSON, options.data);
+        delete options.data;
     }
 
     // Default JSON-request options.
@@ -60,7 +66,7 @@ Backbone.sync = function(method, model, options) {
         contentType:  'application/json',
         data:         (modelJSON || null),
         dataType:     'json',
-        processData:  method === 'read',
+        processData:  method === 'read'
     }, options);
 
     // Make the request.

--- a/client/backbone.js
+++ b/client/backbone.js
@@ -47,16 +47,15 @@ Backbone.sync = function(method, model, options) {
         'read'  : 'GET'
     }[method];
 
-    var modelJSON = model.toJSON ? model.toJSON() : model;
     if (method !== 'read') {
+        var modelJSON = model.toJSON ? model.toJSON() : model;
+        // Merge query string with model attributes
+        if (options.data) {
+            modelJSON = _.extend(modelJSON, options.data);
+            delete options.data;
+        }
         modelJSON['bones.token'] = Backbone.csrf(getUrl(model));
         modelJSON = JSON.stringify(modelJSON);
-    }
-
-    // Merge query string with model attributes
-    if (options.data) {
-        modelJSON = _.extend(modelJSON, options.data);
-        delete options.data;
     }
 
     // Default JSON-request options.

--- a/client/backbone.js
+++ b/client/backbone.js
@@ -54,16 +54,14 @@ Backbone.sync = function(method, model, options) {
     }
 
     // Default JSON-request options.
-    var params = {
+    var params = _.extend({
         url:          getUrl(model),
         type:         type,
         contentType:  'application/json',
         data:         (modelJSON || null),
         dataType:     'json',
-        processData:  false,
-        success:      options.success,
-        error:        options.error
-    };
+        processData:  method === 'read',
+    }, options);
 
     // Make the request.
     return $.ajax(params);

--- a/servers/Route.bones.js
+++ b/servers/Route.bones.js
@@ -128,7 +128,8 @@ server.prototype.getModel = function(req, res, next) {
         }
     };
     if (!_.isEmpty(req.query)) {
-        options = _.extend(options, {data: req.query});
+        // Send query string to server-side sync
+        options = _.extend(options, {query: req.query});
     }
     req.model.fetch(options);
 };

--- a/servers/Route.bones.js
+++ b/servers/Route.bones.js
@@ -93,7 +93,7 @@ server.prototype.loadCollection = function(req, res, next) {
     if (name in this.models) {
         // Pass any querystring paramaters to the collection.
         req.collection = new this.models[name]([], req.query);
-        req.collection.fetch({
+        var options = {
             success: function(collection, resp) {
                 res.send(resp, headers);
             },
@@ -101,7 +101,12 @@ server.prototype.loadCollection = function(req, res, next) {
                 var error = err instanceof Object ? err.message : err;
                 next(new Error.HTTP(error, err && err.status || 500));
             }
-        });
+        };
+        if (!_.isEmpty(req.query)) {
+            // Send query string to server-side sync
+            options = _.extend(options, {query: req.query});
+        }
+        req.collection.fetch(options);
     } else {
         next();
     }

--- a/servers/Route.bones.js
+++ b/servers/Route.bones.js
@@ -118,7 +118,7 @@ server.prototype.loadModel = function(req, res, next) {
 
 server.prototype.getModel = function(req, res, next) {
     if (!req.model) return next();
-    req.model.fetch({
+    var options = {
         success: function(model, resp) {
             res.send(resp, headers);
         },
@@ -126,7 +126,11 @@ server.prototype.getModel = function(req, res, next) {
             var error = err instanceof Object ? err.message : err;
             next(new Error.HTTP(error, err && err.status || 404));
         }
-    });
+    };
+    if (!_.isEmpty(req.query)) {
+        options = _.extend(options, {data: req.query});
+    }
+    req.model.fetch(options);
 };
 
 server.prototype.saveModel = function(req, res, next) {

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -13,7 +13,11 @@ Bones.utils.callback = function(callback) {
 };
 
 // Multifetch. Pass a hash of models and fetch each in parallel.
-Bones.utils.fetch = function(models, callback) {
+Bones.utils.fetch = function(models, data, callback) {
+    if (typeof data === 'function') {
+        callback = data;
+        data = {};
+    }
     var remaining = _(models).size();
     var error = null;
     _(models).each(function(model) {
@@ -25,7 +29,8 @@ Bones.utils.fetch = function(models, callback) {
                 if (!error) error = err;
                 model.error = err;
                 if (--remaining === 0) callback(error, models);
-            }
+            },
+            data: data
         });
     });
 };


### PR DESCRIPTION
The Backbone.sync override in Bones prevents us from passing [AJAX settings](http://api.jquery.com/jQuery.ajax). This change enables this behavior so that model requests can fire all configured [AJAX Events](http://docs.jquery.com/Ajax_Events).

Passing `{data: ...}` to `model.fetch()` (as per the documentation for `$.ajax()`) will make the query string available in `options.query` in the server-side `prototype.sync()`.

This change also makes the `Backbone.sync` override in Bones behave more closely to the original function in [backbone.js](https://github.com/documentcloud/backbone/blob/master/backbone.js#L1364).
