### PR TITLE
Set model body on delete and override request body id with id from URL

### DIFF
--- a/servers/Route.bones
+++ b/servers/Route.bones
@@ -146,7 +146,7 @@ server.prototype.delModel = function(req, res, next) {
     if (!req.model) return next();
     req.model.destroy({
         success: function(model, resp) {
-            res.send({}, headers);
+            res.send(resp, headers);
         },
         error: function(model, err) {
             var error = err instanceof Object ? err.message : err;

--- a/servers/Route.bones
+++ b/servers/Route.bones
@@ -110,6 +110,9 @@ server.prototype.loadCollection = function(req, res, next) {
 server.prototype.loadModel = function(req, res, next) {
     var name = req.params.model;
     if (name in this.models) {
+        // `id` in param wins over `id` in request body.
+        if (req.body && 'id' in req.body && req.params.id)
+            req.body.id = req.params.id;
         // Pass any querystring paramaters to the model.
         req.model = new this.models[name]({ id: req.params.id }, req.query);
     }

--- a/servers/Route.bones
+++ b/servers/Route.bones
@@ -144,6 +144,9 @@ server.prototype.saveModel = function(req, res, next) {
 
 server.prototype.delModel = function(req, res, next) {
     if (!req.model) return next();
+    if (req.body && !req.model.set(req.body, {
+        error: function(model, err) { next(err); }
+    })) return;
     req.model.destroy({
         success: function(model, resp) {
             res.send(resp, headers);


### PR DESCRIPTION
This pull does two main things:
- Set the model attributies based on the request body for `DELETE` requests
- Override the id in the request body with the id provided as a URL param.
